### PR TITLE
Method naming fix.

### DIFF
--- a/src/components/Messenger/Conversation/Content/Messages.js
+++ b/src/components/Messenger/Conversation/Content/Messages.js
@@ -127,8 +127,8 @@ Messages.propTypes = {
   username: PropTypes.string.isRequired,
 }
 
-const mapStateToDispatch = (dispatch) => ({
+const mapDispatchToProps = (dispatch) => ({
   dispatch
 })
 
-export default connect(null, mapStateToDispatch)(Messages)
+export default connect(null, mapDispatchToProps)(Messages)


### PR DESCRIPTION
Changed from mapStateToDispatch to mapDispatchToProps.