### PR TITLE
Tweak the threads test so that, if you write the reducer so that it c…

### DIFF
--- a/tests/in-this-sequence.spec.js
+++ b/tests/in-this-sequence.spec.js
@@ -29,9 +29,24 @@ describe("The threadReducer in src/reducers/index.js", () => {
   })
 
   it("should handle the action type called RECEIVE_THREAD and put action.thread in the state", () => {
-    const state = threadReducer([], { type: 'RECEIVE_THREAD', thread: [2, 3] })
+    
+    const thread = {
+      "lastMessage": {
+        "message": "I love it! specially the feedback form at the end, I can't wait to it xD",
+        "time": "2018-02-11T12:33:00Z"
+      },
+      "name": {
+        "title": "miss",
+        "first": "mary",
+        "last": "jones"
+      },
+      "email": "mary.jones56@example.com",
+      "username": "crazypeacock512"
+    }
 
-    expect(state).toEqual([2, 3])
+    const state = threadReducer([], { type: 'RECEIVE_THREAD', thread })
+
+    expect(state).toEqual({...thread, lastMessage:{...thread.lastMessage}, name:{...thread.name}})
   })
 })
 


### PR DESCRIPTION
Tweak the threads test so that, if you write the reducer so that it copies the action.thread into the state, assuming it is an object (like in the actual app) rather than simply referencing it, the test will pass.  Previously, the test thread is an array, while the app thread is an object, meaning that if all the tests pass (having written the reducer to copy rather than  reference) the app will not run.